### PR TITLE
Add error handling to build.rs file copy operations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,11 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    fs::copy("com.ld", Path::new(&out_dir).join("com.ld"));
-    fs::copy("startup.o", Path::new(&out_dir).join("startup.o"));
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR environment variable not set");
+    
+    fs::copy("com.ld", Path::new(&out_dir).join("com.ld"))
+        .expect("Failed to copy com.ld to output directory. Make sure com.ld exists in the project root.");
+    
+    fs::copy("startup.o", Path::new(&out_dir).join("startup.o"))
+        .expect("Failed to copy startup.o to output directory. Make sure startup.o exists in the project root.");
 }


### PR DESCRIPTION
## Summary
- Adds error handling to the `build.rs` script for copying files
- Replaces `unwrap` calls with `expect` to provide clear error messages
- Ensures that missing environment variables or files produce informative errors

## Changes

### Build Script (`build.rs`)
- Changed `env::var("OUT_DIR").unwrap()` to `expect` with a descriptive error message
- Added `expect` to `fs::copy` calls for `com.ld` and `startup.o` to handle file copy failures
- Error messages guide the user to check the presence of required files in the project root

## Test plan
- [x] Build the project and verify that missing `OUT_DIR` environment variable triggers the correct error
- [x] Remove `com.ld` or `startup.o` and confirm the build fails with the appropriate error message
- [x] Confirm successful build when all files are present and environment variable is set

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/991f33c3-2df2-423d-ae37-fb0911752641